### PR TITLE
ligo-followup-advocate v1.2.11

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ligo-followup-advocate" %}
-{% set version = "1.2.11” %}
+{% set version = "1.2.11" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ligo-followup-advocate" %}
-{% set version = "1.2.10" %}
+{% set version = "1.2.11” %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 8fabdc381bbfc374bbf3c6cc6a97a8b69a5d801024c2f39472c1752263a37ef8
+  sha256: ebbf304eb28355209f8c0e680c57cf2541a63772416c224398773c88651a7a2f
 
 build:
   number: 2


### PR DESCRIPTION
This is copy of https://github.com/conda-forge/ligo-followup-advocate-feedstock/pull/39, being replaced since I rebased incorrectly and don't have the permissions to fix myself.